### PR TITLE
Unclassified endpoint

### DIFF
--- a/src/main/java/org/protege/editor/owl/server/http/HTTPServer.java
+++ b/src/main/java/org/protege/editor/owl/server/http/HTTPServer.java
@@ -202,6 +202,7 @@ public final class HTTPServer {
 		webRouter.add("GET", PROJECT,  metaprojectHandler);
 		webRouter.add("GET", PROJECT_SNAPSHOT,  metaprojectHandler);
 		webRouter.add("GET", PROJECTS, metaprojectHandler);
+		webRouter.add("GET", PROJECTS_UNCLASSIFIED, metaprojectHandler);
 		
 		adminRouter.add("GET", METAPROJECT, metaprojectHandler);
 		adminRouter.add("POST", METAPROJECT, metaprojectHandler);

--- a/src/main/java/org/protege/editor/owl/server/http/ServerEndpoints.java
+++ b/src/main/java/org/protege/editor/owl/server/http/ServerEndpoints.java
@@ -15,6 +15,7 @@ public class ServerEndpoints {
 	public static final String PROJECT = ROOT_PATH + "/meta/project";
 	public static final String PROJECT_SNAPSHOT = ROOT_PATH + "/meta/project/snapshot";
 	public static final String PROJECTS = ROOT_PATH + "/meta/projects";
+	public static final String PROJECTS_UNCLASSIFIED = ROOT_PATH + "/meta/projects/unclassified";
 	public static final String METAPROJECT = ROOT_PATH + "/meta/metaproject";
 
 	public static final String ALL_CHANGES = ROOT_PATH + "/all_changes"; 

--- a/src/main/java/org/protege/editor/owl/server/http/handlers/MetaprojectHandler.java
+++ b/src/main/java/org/protege/editor/owl/server/http/handlers/MetaprojectHandler.java
@@ -24,6 +24,7 @@ import org.protege.editor.owl.server.http.exception.ServerException;
 import org.protege.editor.owl.server.security.LoginTimeoutException;
 import org.protege.editor.owl.server.util.SnapShot;
 import org.protege.editor.owl.server.versioning.api.ServerDocument;
+import org.protege.osgi.framework.Server;
 import org.semanticweb.binaryowl.BinaryOWLOntologyDocumentSerializer;
 import org.semanticweb.binaryowl.owlapi.BinaryOWLOntologyBuildingHandler;
 import org.semanticweb.binaryowl.owlapi.OWLOntologyWrapper;
@@ -152,7 +153,22 @@ public class MetaprojectHandler extends BaseRoutingHandler {
 		try {
 			ObjectOutputStream oos = new ObjectOutputStream(exchange.getOutputStream());
 			List<Project> projects = new ArrayList<>();
-			oos.writeObject(projects);
+			try {
+				for (Project project : serverLayer.getAllProjects(getAuthToken(exchange))) {
+					boolean classifiable = project.getOptions()
+						.map(projectOptions -> projectOptions.getValue("classifiable").equals("true")).orElse(false);
+					if (classifiable) {
+						projects.add(project);
+					}
+				}
+				oos.writeObject(projects);
+			} catch (AuthorizationException e) {
+				throw new ServerException(StatusCodes.UNAUTHORIZED, e);
+			} catch (ServerServiceException e) {
+				throw new ServerException(StatusCodes.INTERNAL_SERVER_ERROR, e);
+			} catch (LoginTimeoutException e) {
+				throw new RuntimeException(e);
+			}
 		} catch (IOException e) {
 			throw new ServerException(StatusCodes.INTERNAL_SERVER_ERROR, "Server failed to transmit returned data", e);
 		}

--- a/src/main/java/org/protege/editor/owl/server/http/handlers/MetaprojectHandler.java
+++ b/src/main/java/org/protege/editor/owl/server/http/handlers/MetaprojectHandler.java
@@ -142,6 +142,19 @@ public class MetaprojectHandler extends BaseRoutingHandler {
 			ServerConfiguration cfg = serl.parse(new InputStreamReader(exchange.getInputStream()), ServerConfiguration.class);
 			updateMetaproject(cfg);
 			requiredRestarting = true;
+		} else if (requestPath.equals(ServerEndpoints.PROJECTS_UNCLASSIFIED) && requestMethod.equals(Methods.GET)) {
+        retrieveProjectsUnclassified(exchange);
+    }
+	}
+
+
+	public void retrieveProjectsUnclassified(HttpServerExchange exchange) throws ServerException {
+		try {
+			ObjectOutputStream oos = new ObjectOutputStream(exchange.getOutputStream());
+			List<Project> projects = new ArrayList<>();
+			oos.writeObject(projects);
+		} catch (IOException e) {
+			throw new ServerException(StatusCodes.INTERNAL_SERVER_ERROR, "Server failed to transmit returned data", e);
 		}
 	}
 


### PR DESCRIPTION
Add endpoint to return all unclassified projects. The endpoint returns an empty
project list for now. It only defines the interface. Will add the server call shortly.

- [ ] Add server call to fetch metaprojects with unclassified=true