### PR TITLE
Improve error when initing login service

### DIFF
--- a/src/main/java/org/protege/editor/owl/server/base/ProtegeServer.java
+++ b/src/main/java/org/protege/editor/owl/server/base/ProtegeServer.java
@@ -1,5 +1,6 @@
 package org.protege.editor.owl.server.base;
 
+import com.google.common.base.Strings;
 import edu.stanford.protege.metaproject.ConfigurationManager;
 import edu.stanford.protege.metaproject.api.*;
 import edu.stanford.protege.metaproject.api.exception.*;
@@ -699,6 +700,9 @@ public class ProtegeServer extends ServerLayer {
     private void saveChanges() throws ServerServiceException {
         try {
             String configLocation = System.getProperty(HTTPServer.SERVER_CONFIGURATION_PROPERTY);
+            if (Strings.isNullOrEmpty(configLocation)) {
+            	throw new RuntimeException("Config property " + HTTPServer.SERVER_CONFIGURATION_PROPERTY + " isn't set");
+						}
             File configurationFile = new File(configLocation);
             ConfigurationManager.getConfigurationWriter().saveConfiguration(configuration, configurationFile);
         }

--- a/src/main/java/org/protege/editor/owl/server/http/HTTPServer.java
+++ b/src/main/java/org/protege/editor/owl/server/http/HTTPServer.java
@@ -273,19 +273,20 @@ public final class HTTPServer {
 		isRunning = true;
 	}
 
+	@Nonnull
 	private LoginService instantiateLoginService() throws ServerException {
 		String authClassName = serverConfiguration.getProperty(AUTHENTICATION_CLASS);
-		LoginService service = null;
-		if (authClassName != null) {
-			try {
-				service = (LoginService) Class.forName(authClassName).newInstance();
-				service.setConfig(serverConfiguration);
-				
-			} catch (ClassNotFoundException | InstantiationException | IllegalAccessException e) {
-				throw new ServerException(StatusCodes.INTERNAL_SERVER_ERROR, e.getMessage());
-			}
+		if (authClassName == null) {
+			throw new RuntimeException("Failed to initialize LoginService. " + AUTHENTICATION_CLASS + " property not set");
 		}
-		return service;
+		try {
+			LoginService service = (LoginService) Class.forName(authClassName).newInstance();
+			service.setConfig(serverConfiguration);
+			return service;
+
+		} catch (ClassNotFoundException | InstantiationException | IllegalAccessException e) {
+			throw new ServerException(StatusCodes.INTERNAL_SERVER_ERROR, e.getMessage());
+		}
 	}
 
 	private TokenTable createLoginTokenTable() {


### PR DESCRIPTION
if the `authenticate` property isn't set then we can't initialize the
LoginService. Hence we should just error out immediately rather than returning
null. As the only caller of this function expects a non null.