### PR TITLE
Handle projects without classified field

### DIFF
--- a/src/main/java/org/protege/editor/owl/server/http/handlers/MetaprojectHandler.java
+++ b/src/main/java/org/protege/editor/owl/server/http/handlers/MetaprojectHandler.java
@@ -151,7 +151,9 @@ public class MetaprojectHandler extends BaseRoutingHandler {
 			try {
 				for (Project project : serverLayer.getAllProjects(getAuthToken(exchange))) {
 					boolean classifiable = project.getOptions()
-						.map(projectOptions -> projectOptions.getValue("classifiable").equals("true")).orElse(false);
+						.flatMap(projectOptions -> Optional.ofNullable(projectOptions.getValue("classifiable")))
+						.map(classify -> classify.equals("true"))
+						.orElse(false);
 					if (classifiable) {
 						projects.add(project);
 					}


### PR DESCRIPTION
When classified isn't set, it should just default to false